### PR TITLE
Pipeline trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Circle CI dynamic pipelines (https://circleci.com/docs/using-dynamic-configurati
 
 Use this starting template in your project's `.circleci/config.yml` file.
 
-Adjust the following JSON parameters that are passed into the pipeline continuation step.:
+Adjust the following JSON parameters that are passed into the pipeline continuation step:
 
 - `php_version`: make sure this matches your production value.
 - `drupal_core_version`: Set as required.


### PR DESCRIPTION
- Circle CI project needs set up so it knows to build on this repo and only on PR creation.
- `build-test` should be specified on GH branch protection rules to ensure the CI jobs validate the YML and can compose/preprocess it in a way that dynamic pipelines will use it.