### PR TITLE
Use recommended project matching non-dev version of the core version

### DIFF
--- a/shared-config.yml
+++ b/shared-config.yml
@@ -244,7 +244,7 @@ jobs:
           name: Fetch Drupal core
           command: |
             cd $PROJECT_ROOT
-            composer create-project drupal/recommended-project:<< parameters.drupal_core_version >>.x-dev $PROJECT_ROOT --no-interaction
+            composer create-project drupal/recommended-project:^<< parameters.drupal_core_version >> $PROJECT_ROOT --no-interaction
       - run:
           name: Download dependent contrib modules.
           command: |
@@ -281,7 +281,7 @@ jobs:
           name: Fetch latest Drupal core and other misc composer tools.
           command: |
             cd $PROJECT_ROOT
-            composer create-project drupal/recommended-project:<< parameters.drupal_core_version >>.x-dev $PROJECT_ROOT --no-interaction
+            composer create-project drupal/recommended-project:^<< parameters.drupal_core_version >> $PROJECT_ROOT --no-interaction
             composer require --dev phpstan/extension-installer spaze/phpstan-disallowed-calls
       - run:
           name: Move custom code into position


### PR DESCRIPTION
Given in the pipeline parameters. So if you specify 11.2 you'll get 11.2.0 or 11.2.1, depending on which minor version is most recent. You won't get 11.3 unless you tweak the project pipeline parameters to evaluate your code against more substantial and recent releases.