### PR TITLE
New phpstan job

### DIFF
--- a/shared-config.yml
+++ b/shared-config.yml
@@ -258,6 +258,45 @@ jobs:
           command: |
             cd $PROJECT_ROOT/web
             ../vendor/bin/drupal-check << parameters.custom_code_dirs >>
+  supporting_repo_phpstan:
+    parameters:
+      custom_code_dirs:
+        type: string
+      drupal_core_version:
+        type: string
+      php_version:
+        type: string
+      supporting_repo_dependent_packages:
+        type: string
+    docker:
+      - image: thecodingmachine/php:<< parameters.php_version >>-v4-fpm
+        environment:
+          PLATFORM_REGION: "uk-1.platform.sh"
+          PROJECT_ROOT: "/home/docker/project"
+          PHP_EXTENSION_GD: 1
+          PHP_INI_MEMORY_LIMIT: 1g
+    steps:
+      - checkout:
+          path: ~/dofdss
+      - run:
+          name: Fetch Drupal core
+          command: |
+            cd $PROJECT_ROOT
+            composer create-project drupal/recommended-project:^<< parameters.drupal_core_version >> $PROJECT_ROOT --no-interaction
+      - run:
+          name: Download dependent contrib modules.
+          command: |
+            cd $PROJECT_ROOT
+            composer require << parameters.supporting_repo_dependent_packages >>
+      - run:
+          name: Move custom code into position
+          command: mv ~/dofdss << parameters.custom_code_dirs >>
+      - run:
+          name: Deprecated code check
+          command: |
+            cd $PROJECT_ROOT/web
+            cp $PROJECT_ROOT/.circleci/phpstan.neon ./
+            ../vendor/bin/phpstan analyse --memory-limit=$PHP_INI_MEMORY_LIMIT << parameters.custom_code_dirs >>
   supporting_repo_disallowed_functions:
     parameters:
       custom_code_dirs:

--- a/shared-config.yml
+++ b/shared-config.yml
@@ -279,24 +279,30 @@ jobs:
       - checkout:
           path: ~/dofdss
       - run:
+          name: Move phpstan.neon into place for later use.
+          command: mv ~/dofdss/.circleci/phpstan.neon ~/
+      - run:
           name: Fetch Drupal core
           command: |
             cd $PROJECT_ROOT
             composer create-project drupal/recommended-project:^<< parameters.drupal_core_version >> $PROJECT_ROOT --no-interaction
       - run:
-          name: Download dependent contrib modules.
+          name: Download dependent contrib modules and dev packages.
           command: |
             cd $PROJECT_ROOT
             composer require << parameters.supporting_repo_dependent_packages >>
+            composer require --dev phpstan/extension-installer spaze/phpstan-disallowed-calls
       - run:
           name: Move custom code into position
           command: mv ~/dofdss << parameters.custom_code_dirs >>
       - run:
+          name: Move phpstan.neon into position
+          command: mv ~/phpstan.neon $PROJECT_ROOT/web/
+      - run:
           name: Deprecated code check
           command: |
-            cd $PROJECT_ROOT/web
-            cp $PROJECT_ROOT/.circleci/phpstan.neon ./
-            ../vendor/bin/phpstan analyse --memory-limit=$PHP_INI_MEMORY_LIMIT << parameters.custom_code_dirs >>
+            cd $PROJECT_ROOT
+            vendor/bin/phpstan analyse -c web/phpstan.neon --memory-limit=$PHP_INI_MEMORY_LIMIT << parameters.custom_code_dirs >>
   supporting_repo_disallowed_functions:
     parameters:
       custom_code_dirs:

--- a/shared-config.yml
+++ b/shared-config.yml
@@ -185,6 +185,25 @@ jobs:
       - run:
           name: Check for disallowed function calls
           command: vendor/bin/phpstan analyse << parameters.custom_code_dirs >> -c .circleci/phpstan.neon
+  deprecated_code_phpstan:
+    parameters:
+      php_version:
+        type: string
+      deprecated_code_dirs:
+        type: string
+    docker:
+      - image: thecodingmachine/php:<< parameters.php_version >>-v4-fpm
+        environment:
+          PLATFORM_REGION: "uk-1.platform.sh"
+          PROJECT_ROOT: "/home/docker/project"
+          PHP_EXTENSION_GD: 1
+          PHP_INI_MEMORY_LIMIT: 1g
+    steps:
+      - attach_workspace:
+          at: ./
+      - run:
+          name: Deprecated code check
+          command: cd $PROJECT_ROOT && vendor/bin/phpstan analyse --memory-limit=$PHP_INI_MEMORY_LIMIT << parameters.deprecated_code_dirs >>
   # SUPPORTING REPO jobs: used because Circle CI can't make things like attach_workspace
   # and checkout conditional so these are replicas of related jobs with minor functional adjustments.
   supporting_repo_coding_standards:

--- a/shared-config.yml
+++ b/shared-config.yml
@@ -238,7 +238,7 @@ jobs:
             chmod +x $PROJECT_ROOT/phpcs.sh
       - run:
           name: PHPCS analysis
-          command: $PROJECT_ROOT/phpcs.sh ~/ "${PROJECT_ROOT}"
+          command: $PROJECT_ROOT/phpcs.sh ~/ "${PROJECT_ROOT}" $PROJECT_ROOT/node_modules
   supporting_repo_deprecated_code:
     parameters:
       custom_code_dirs:


### PR DESCRIPTION
Supersedes drupal-check job, which can be sunsetted once other referencing projects have stopped using it