### PR TITLE
Rebuild edge Solr indexes on version changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,38 @@ reads the live Solr version from that source environment, and passes it to the
 edge environment. An edge Search API index is cleared and rebuilt only when its
 live Solr version differs from the source version.
 
+This is needed because `platform sync data` copies Drupal's database and files,
+but the source and edge environments can have different Solr service versions.
+The copied database includes Search API tracker state, while the edge Solr index
+remains a separate service. When versions differ, rebuilding makes the tracker
+and index reflect work performed against the edge service. Tracker and document
+counts are deliberately not used: Search API processors can reject documents
+while still marking them processed, so unequal counts are not by themselves
+evidence of a broken index.
+
+### Execution flow
+
+1. CircleCI asks Platform.sh for the edge environment's parent—the same
+   environment used as the data-sync source.
+2. It downloads the helper from `webdev-ci/main` and verifies its SHA-256 hash
+   against the shared configuration.
+3. It runs the helper in `detect` mode on the source. This reads enabled
+   Search API Solr indexes and requires one unambiguous live version.
+4. It runs the helper in `reconcile` mode on the edge, passing that source
+   version as `SOURCE_SOLR_VERSION`.
+5. Matching indexes are logged and left untouched. Differing indexes receive
+   one Drupal cache rebuild per site, followed by a clear and chunked rebuild.
+
+If source and edge intentionally remain on different Solr versions, the edge
+indexes are rebuilt after every data sync. This is intentional: each sync
+refreshes Drupal's database and tracker state from that differently versioned
+source environment.
+
+The command fails rather than guessing if the source environment cannot be
+identified, Drupal or Solr is unavailable, version detection returns `0.0.0`,
+multiple source versions are found, clearing fails, or indexing stops making
+progress.
+
 The script supports both repository layouts used by the consuming projects:
 
 - `project/sites` for Unity and Corp Lite multisite projects.
@@ -78,6 +110,51 @@ with `DRUPAL_ROOT`, when a project uses another layout. Versions are detected
 from each environment's live Search API Solr connector; no project-specific
 Solr version is hard-coded in the shared configuration. If the versions match,
 the command does not inspect counts or mutate the index.
+
+### Script modes and local debugging
+
+`detect` is read-only and can be run inside a downstream project's DDEV
+container from the project root:
+
+```bash
+ddev exec env PLATFORM_APP_DIR=/var/www/html \
+  bash -s -- detect \
+  < /path/to/webdev-ci/scripts/reconcile-solr-indexes.sh
+```
+
+`reconcile` requires a three-part source version. Supplying a version different
+from local Solr deliberately clears and rebuilds the local indexes:
+
+```bash
+ddev exec env \
+  PLATFORM_APP_DIR=/var/www/html \
+  SOURCE_SOLR_VERSION=9.9.0 \
+  CHUNK_PAUSE_SECONDS=0 \
+  INDEX_PAUSE_SECONDS=0 \
+  SITE_PAUSE_SECONDS=0 \
+  SOLR_READY_DELAY_SECONDS=0 \
+  bash -s -- reconcile \
+  < /path/to/webdev-ci/scripts/reconcile-solr-indexes.sh
+```
+
+Use `bash -x -s` instead of `bash -s` to trace commands during local debugging.
+There is no separate dry-run mode: `detect` is the safe inspection mode, while
+`reconcile` is allowed to mutate indexes when versions differ.
+
+### Tuning
+
+The defaults are intended to reduce sustained load on shared environments:
+
+- `INDEX_CHUNK_SIZE=500` and `INDEX_BATCH_SIZE=25` bound each indexing call.
+- `CHUNK_PAUSE_SECONDS=5`, `INDEX_PAUSE_SECONDS=10`, and
+  `SITE_PAUSE_SECONDS=20` throttle work between batches, indexes, and sites.
+- `SOLR_READY_RETRIES=12`, `SOLR_READY_DELAY_SECONDS=10`, and
+  `CLEAR_RETRIES=3` allow a temporarily loading core to become available.
+
+These values can be overridden as environment variables. Pause values may be
+zero; chunk sizes and retry counts must remain greater than zero.
+
+### Tests
 
 Run the focused regression coverage with:
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,31 @@ jobs:
 - YAML anchors can't be preprocessed with pipeline parameters (yet), so you'll see these re-declared to prioritise parameter usage over lack of repetition.
 - There's a preprocess/setup step involved now where a continuation orb will take the central config file, and preprocess it into a final YAML file which is then executed in the usual workflow steps.
 
+## Edge Solr version reconciliation
+
+The shared edge-finalisation jobs run `scripts/reconcile-solr-indexes.sh` after
+the data sync. The CircleCI command detects the edge environment's parent,
+reads the live Solr version from that source environment, and passes it to the
+edge environment. An edge Search API index is cleared and rebuilt only when its
+live Solr version differs from the source version.
+
+The script supports both repository layouts used by the consuming projects:
+
+- `project/sites` for Unity and Corp Lite multisite projects.
+- `web/sites` for DEPT, nidirect, and other standard Drupal projects.
+
+The sites directory can be overridden with `SITES_ROOT`, and the Drupal root
+with `DRUPAL_ROOT`, when a project uses another layout. Versions are detected
+from each environment's live Search API Solr connector; no project-specific
+Solr version is hard-coded in the shared configuration. If the versions match,
+the command does not inspect counts or mutate the index.
+
+Run the focused regression coverage with:
+
+```bash
+bash scripts/tests/reconcile-solr-indexes.sh
+```
+
 ## Contribution
 
 > Contributors to repositories hosted in dof-dss are expected to follow the Contributor Covenant Code of Conduct, and those working within Government are also expected to follow the Northern Civil Service Code of Ethics and Civil Service Code. For details see https://github.com/dof-dss/contributor-code-of-conduct

--- a/README.md
+++ b/README.md
@@ -64,9 +64,8 @@ jobs:
 
 The shared edge-finalisation jobs run `scripts/reconcile-solr-indexes.sh` after
 the data sync. The CircleCI command detects the edge environment's parent,
-reads the live Solr version from that source environment, and passes it to the
-edge environment. An edge Search API index is cleared and rebuilt only when its
-live Solr version differs from the source version.
+reads the Solr service types declared for the source and edge environments, and
+only runs the helper when those declared versions differ.
 
 This is needed because `platform sync data` copies Drupal's database and files,
 but the source and edge environments can have different Solr service versions.
@@ -81,14 +80,16 @@ evidence of a broken index.
 
 1. CircleCI asks Platform.sh for the edge environment's parent—the same
    environment used as the data-sync source.
-2. It downloads the helper from `webdev-ci/main` and verifies its SHA-256 hash
-   against the shared configuration.
-3. It runs the helper in `detect` mode on the source. This reads enabled
-   Search API Solr indexes and requires one unambiguous live version.
-4. It runs the helper in `reconcile` mode on the edge, passing that source
-   version as `SOURCE_SOLR_VERSION`.
-5. Matching indexes are logged and left untouched. Differing indexes receive
-   one Drupal cache rebuild per site, followed by a clear and chunked rebuild.
+2. It uses `platform services` to read the service types deployed to the source
+   and edge environments. DDEV configuration is not used for this production
+   decision.
+3. If the edge declares no Solr service, or both environments declare the same
+   Solr version, the command exits successfully without bootstrapping Drupal.
+4. If the edge declares a different Solr version, CircleCI downloads the latest
+   helper from `webdev-ci/main` and runs it only in the edge environment.
+5. The helper discovers enabled Search API Solr indexes. Each affected site
+   receives one Drupal cache rebuild followed by a clear and chunked rebuild.
+   Sites without an enabled Solr index are logged and skipped.
 
 If source and edge intentionally remain on different Solr versions, the edge
 indexes are rebuilt after every data sync. This is intentional: each sync
@@ -96,9 +97,8 @@ refreshes Drupal's database and tracker state from that differently versioned
 source environment.
 
 The command fails rather than guessing if the source environment cannot be
-identified, Drupal or Solr is unavailable, version detection returns `0.0.0`,
-multiple source versions are found, clearing fails, or indexing stops making
-progress.
+identified, an environment declares multiple Solr service versions, an affected
+site cannot reach Solr, clearing fails, or indexing stops making progress.
 
 The script supports both repository layouts used by the consuming projects:
 
@@ -106,40 +106,30 @@ The script supports both repository layouts used by the consuming projects:
 - `web/sites` for DEPT, nidirect, and other standard Drupal projects.
 
 The sites directory can be overridden with `SITES_ROOT`, and the Drupal root
-with `DRUPAL_ROOT`, when a project uses another layout. Versions are detected
-from each environment's live Search API Solr connector; no project-specific
-Solr version is hard-coded in the shared configuration. If the versions match,
-the command does not inspect counts or mutate the index.
+with `DRUPAL_ROOT`, when a project uses another layout. No project-specific Solr
+version is hard-coded in the shared configuration.
 
-### Script modes and local debugging
+### Local debugging
 
-`detect` is read-only and can be run inside a downstream project's DDEV
-container from the project root:
-
-```bash
-ddev exec env PLATFORM_APP_DIR=/var/www/html \
-  bash -s -- detect \
-  < /path/to/webdev-ci/scripts/reconcile-solr-indexes.sh
-```
-
-`reconcile` requires a three-part source version. Supplying a version different
-from local Solr deliberately clears and rebuilds the local indexes:
+The helper is rebuild-only because CircleCI makes the version decision before
+invoking it. Running it directly in DDEV therefore clears and rebuilds every
+enabled local Search API Solr index. Use a disposable local index:
 
 ```bash
 ddev exec env \
   PLATFORM_APP_DIR=/var/www/html \
-  SOURCE_SOLR_VERSION=9.9.0 \
   CHUNK_PAUSE_SECONDS=0 \
   INDEX_PAUSE_SECONDS=0 \
   SITE_PAUSE_SECONDS=0 \
   SOLR_READY_DELAY_SECONDS=0 \
-  bash -s -- reconcile \
+  bash -s \
   < /path/to/webdev-ci/scripts/reconcile-solr-indexes.sh
 ```
 
 Use `bash -x -s` instead of `bash -s` to trace commands during local debugging.
-There is no separate dry-run mode: `detect` is the safe inspection mode, while
-`reconcile` is allowed to mutate indexes when versions differ.
+There is no dry-run mode in the helper. To inspect the declared Upsun versions
+without rebuilding, use `platform services --columns type` for the source and
+edge environments.
 
 ### Tuning
 

--- a/scripts/reconcile-solr-indexes.sh
+++ b/scripts/reconcile-solr-indexes.sh
@@ -1,8 +1,41 @@
 #!/usr/bin/env bash
 
-# Compare the live Solr version in a data-sync source environment with the
-# version used by each Search API Solr index in the target environment. Rebuild
-# only indexes whose target version differs from the source version.
+# Reconcile Search API Solr indexes after copying Drupal data into an edge
+# environment whose Solr service may run a different version.
+#
+# Why this exists
+# ---------------
+# `platform sync data` copies Drupal's database and files, but it does not make
+# the source and target Solr services the same version. The copied database
+# includes Search API tracker state, while the edge Solr index remains a
+# separate service. When versions differ, clearing and rebuilding makes the
+# target tracker and index agree on work performed against the target service.
+# Tracker and document counts are not used as the decision boundary because
+# processors can legitimately make those counts differ.
+#
+# Modes
+# -----
+#   detect
+#     Read every enabled Search API Solr index and emit one machine-readable
+#     `DETECTED_SOLR_VERSION<TAB>x.y.z` line. This mode never clears or indexes.
+#     It fails if no version, version 0.0.0, or multiple versions are detected.
+#
+#   reconcile (default)
+#     Compare each target index's detected live version with the required
+#     SOURCE_SOLR_VERSION environment variable. Matching indexes are untouched;
+#     differing indexes are cleared and fully rebuilt in bounded chunks.
+#
+# Project layouts and overrides
+# -----------------------------
+# The script discovers Unity/Corp Lite sites under project/sites and standard
+# Drupal projects under web/sites. PLATFORM_APP_DIR defaults to /app, while
+# DRUPAL_ROOT and SITES_ROOT can override non-standard deployments. Chunk sizes,
+# pauses, readiness retries, and clear retries can also be overridden using the
+# variables declared below.
+#
+# The CircleCI command runs `detect` in the data-sync source environment, then
+# passes its result to `reconcile` in the edge environment. The script can also
+# be piped into a DDEV container for local diagnostics; see README.md.
 
 set -uo pipefail
 
@@ -102,6 +135,9 @@ drush_for_site() {
 discover_solr_indexes() {
   local site="$1"
 
+  # Restrict work to enabled Search API indexes backed by Search API Solr.
+  # The tab-prefixed record makes the useful result distinguishable from any
+  # Drupal/Drush informational output.
   drush_for_site "${site}" php:eval '
     foreach (\Drupal::entityTypeManager()->getStorage("search_api_index")->loadMultiple() as $index) {
       $server = $index->getServerInstanceIfAvailable();
@@ -116,6 +152,8 @@ get_solr_version() {
   local site="$1"
   local index="$2"
 
+  # Force live connector auto-detection. Without TRUE, a configured version
+  # override could hide the actual Solr service version being used.
   RECONCILE_INDEX_ID="${index}" drush_for_site "${site}" php:eval '
     $index = \Drupal::entityTypeManager()
       ->getStorage("search_api_index")
@@ -198,6 +236,9 @@ clear_solr_index() {
     fi
     printf '%s\n' "${clear_output}"
 
+    # Some Drupal hooks emit unrelated errors (for example, a missing Fastly
+    # service ID) even when Search API clears Solr successfully. Treat only a
+    # failed command or a known Solr-specific error as a failed clear.
     if [[ "${clear_succeeded}" == true ]] &&
       ! grep -qE 'SearchApiSolrException|SolrCore is loading|Solr HTTP error|Solr endpoint .*unreachable' <<< "${clear_output}"; then
       return 0
@@ -219,6 +260,8 @@ rebuild_solr_index() {
   local after
   local stalled_attempts=0
 
+  # Process a bounded number of items per Drush call to avoid one long-running
+  # remote command. Abort if three consecutive calls make no tracker progress.
   while true; do
     if ! before=$(get_remaining_items "${site}" "${index}"); then
       return 1
@@ -298,6 +341,7 @@ for site in "${SITES[@]}"; do
     continue
   fi
 
+  # Rebuild Drupal's caches once per affected site before mutating its indexes.
   if ! drush_for_site "${site}" --yes cache:rebuild; then
     echo "ERROR: ${site}: cache rebuild failed." >&2
     for index in "${indexes_to_rebuild[@]}"; do
@@ -333,6 +377,8 @@ if [[ "${MODE}" == detect ]]; then
     echo "ERROR: No live Solr versions were detected in the source environment." >&2
     exit 1
   fi
+  # A single source version is required because CircleCI passes one comparison
+  # value to the target environment. Refuse an ambiguous mixed-version source.
   mapfile -t unique_versions < <(printf '%s\n' "${detected_versions[@]}" | sort -u)
   if (( ${#unique_versions[@]} != 1 )); then
     echo "ERROR: Expected one Solr version across the source environment; found: ${unique_versions[*]:-none}." >&2

--- a/scripts/reconcile-solr-indexes.sh
+++ b/scripts/reconcile-solr-indexes.sh
@@ -1,49 +1,29 @@
 #!/usr/bin/env bash
 
-# Reconcile Search API Solr indexes after copying Drupal data into an edge
-# environment whose Solr service may run a different version.
+# Rebuild enabled Search API Solr indexes in an edge environment.
 #
-# Why this exists
-# ---------------
-# `platform sync data` copies Drupal's database and files, but it does not make
-# the source and target Solr services the same version. The copied database
-# includes Search API tracker state, while the edge Solr index remains a
-# separate service. When versions differ, clearing and rebuilding makes the
-# target tracker and index agree on work performed against the target service.
-# Tracker and document counts are not used as the decision boundary because
-# processors can legitimately make those counts differ.
+# CircleCI compares the Solr service types declared by the data-sync source and
+# target Upsun environments before invoking this helper. It does not invoke the
+# script when the target has no Solr service or when the declared versions
+# match. Keeping that decision in shared-config.yml means this script only needs
+# to perform one job: safely rebuild the target indexes after a version change.
 #
-# Modes
-# -----
-#   detect
-#     Read every enabled Search API Solr index and emit one machine-readable
-#     `DETECTED_SOLR_VERSION<TAB>x.y.z` line. This mode never clears or indexes.
-#     It fails if no version, version 0.0.0, or multiple versions are detected.
+# Sites without an enabled Search API Solr index are logged and skipped. This
+# supports multisite projects where only some sites use search as well as
+# projects that declare a shared Solr service but currently have no active
+# indexes.
 #
-#   reconcile (default)
-#     Compare each target index's detected live version with the required
-#     SOURCE_SOLR_VERSION environment variable. Matching indexes are untouched;
-#     differing indexes are cleared and fully rebuilt in bounded chunks.
-#
-# Project layouts and overrides
-# -----------------------------
 # The script discovers Unity/Corp Lite sites under project/sites and standard
 # Drupal projects under web/sites. PLATFORM_APP_DIR defaults to /app, while
 # DRUPAL_ROOT and SITES_ROOT can override non-standard deployments. Chunk sizes,
-# pauses, readiness retries, and clear retries can also be overridden using the
+# pauses, readiness retries, and clear retries can be overridden using the
 # variables declared below.
-#
-# The CircleCI command runs `detect` in the data-sync source environment, then
-# passes its result to `reconcile` in the edge environment. The script can also
-# be piped into a DDEV container for local diagnostics; see README.md.
 
 set -uo pipefail
 
-MODE="${1:-reconcile}"
 APP_ROOT="${PLATFORM_APP_DIR:-/app}"
 DRUPAL_ROOT="${DRUPAL_ROOT:-${APP_ROOT}/web}"
 SITES_ROOT="${SITES_ROOT:-}"
-SOURCE_SOLR_VERSION="${SOURCE_SOLR_VERSION:-}"
 INDEX_CHUNK_SIZE="${INDEX_CHUNK_SIZE:-500}"
 INDEX_BATCH_SIZE="${INDEX_BATCH_SIZE:-25}"
 CHUNK_PAUSE_SECONDS="${CHUNK_PAUSE_SECONDS:-5}"
@@ -52,17 +32,6 @@ SITE_PAUSE_SECONDS="${SITE_PAUSE_SECONDS:-20}"
 SOLR_READY_RETRIES="${SOLR_READY_RETRIES:-12}"
 SOLR_READY_DELAY_SECONDS="${SOLR_READY_DELAY_SECONDS:-10}"
 CLEAR_RETRIES="${CLEAR_RETRIES:-3}"
-
-if [[ "${MODE}" != detect && "${MODE}" != reconcile ]]; then
-  echo "ERROR: Usage: $0 [detect|reconcile]" >&2
-  exit 1
-fi
-
-if [[ "${MODE}" == reconcile ]] &&
-  { [[ ! "${SOURCE_SOLR_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || [[ "${SOURCE_SOLR_VERSION}" == 0.0.0 ]]; }; then
-  echo "ERROR: SOURCE_SOLR_VERSION must be a detected semantic Solr version." >&2
-  exit 1
-fi
 
 if command -v drush >/dev/null 2>&1; then
   DRUSH=(drush)
@@ -136,8 +105,7 @@ discover_solr_indexes() {
   local site="$1"
 
   # Restrict work to enabled Search API indexes backed by Search API Solr.
-  # The tab-prefixed record makes the useful result distinguishable from any
-  # Drupal/Drush informational output.
+  # The tab-prefixed record distinguishes results from Drush status output.
   drush_for_site "${site}" php:eval '
     foreach (\Drupal::entityTypeManager()->getStorage("search_api_index")->loadMultiple() as $index) {
       $server = $index->getServerInstanceIfAvailable();
@@ -146,25 +114,6 @@ discover_solr_indexes() {
       }
     }
   '
-}
-
-get_solr_version() {
-  local site="$1"
-  local index="$2"
-
-  # Force live connector auto-detection. Without TRUE, a configured version
-  # override could hide the actual Solr service version being used.
-  RECONCILE_INDEX_ID="${index}" drush_for_site "${site}" php:eval '
-    $index = \Drupal::entityTypeManager()
-      ->getStorage("search_api_index")
-      ->load(getenv("RECONCILE_INDEX_ID"));
-    if (!$index) {
-      throw new \RuntimeException("Search API index was not found.");
-    }
-    $backend = $index->getServerInstance()->getBackend();
-    $version = $backend->getSolrConnector()->getSolrVersion(TRUE);
-    printf("SOLR_VERSION\t%s\n", $version);
-  ' | awk -F '\t' '$1 == "SOLR_VERSION" { print $2 }'
 }
 
 get_remaining_items() {
@@ -236,9 +185,8 @@ clear_solr_index() {
     fi
     printf '%s\n' "${clear_output}"
 
-    # Some Drupal hooks emit unrelated errors (for example, a missing Fastly
-    # service ID) even when Search API clears Solr successfully. Treat only a
-    # failed command or a known Solr-specific error as a failed clear.
+    # Ignore unrelated Drupal hook errors when Search API reports a successful
+    # clear, but continue to reject failed commands and known Solr errors.
     if [[ "${clear_succeeded}" == true ]] &&
       ! grep -qE 'SearchApiSolrException|SolrCore is loading|Solr HTTP error|Solr endpoint .*unreachable' <<< "${clear_output}"; then
       return 0
@@ -260,8 +208,7 @@ rebuild_solr_index() {
   local after
   local stalled_attempts=0
 
-  # Process a bounded number of items per Drush call to avoid one long-running
-  # remote command. Abort if three consecutive calls make no tracker progress.
+  # Use bounded Drush calls and abort after three calls without tracker progress.
   while true; do
     if ! before=$(get_remaining_items "${site}" "${index}"); then
       return 1
@@ -299,11 +246,10 @@ rebuild_solr_index() {
   done
 }
 
-detected_versions=()
 failed_indexes=()
 rebuilt_indexes=()
-unchanged_indexes=()
 skipped_sites=()
+sites_without_solr=()
 
 for site in "${SITES[@]}"; do
   if ! index_output=$(discover_solr_indexes "${site}" 2>&1); then
@@ -314,44 +260,22 @@ for site in "${SITES[@]}"; do
 
   mapfile -t solr_indexes < <(awk -F '\t' '$1 == "SOLR_INDEX" { print $2 }' <<< "${index_output}")
   if (( ${#solr_indexes[@]} == 0 )); then
-    continue
-  fi
-
-  indexes_to_rebuild=()
-  for index in "${solr_indexes[@]}"; do
-    if ! target_version=$(get_solr_version "${site}" "${index}") ||
-      [[ ! "${target_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ || "${target_version}" == 0.0.0 ]]; then
-      echo "ERROR: ${site}/${index}: could not detect a live Solr version." >&2
-      failed_indexes+=("${site}/${index} (version detection)")
-      continue
-    fi
-
-    if [[ "${MODE}" == detect ]]; then
-      detected_versions+=("${target_version}")
-    elif [[ "${target_version}" == "${SOURCE_SOLR_VERSION}" ]]; then
-      echo "${site}/${index}: Solr ${target_version} matches the source environment; no rebuild needed."
-      unchanged_indexes+=("${site}/${index}")
-    else
-      echo "${site}/${index}: source Solr=${SOURCE_SOLR_VERSION}, target Solr=${target_version}; scheduling rebuild."
-      indexes_to_rebuild+=("${index}")
-    fi
-  done
-
-  if [[ "${MODE}" == detect ]] || (( ${#indexes_to_rebuild[@]} == 0 )); then
+    echo "${site}: no enabled Search API Solr indexes; skipping."
+    sites_without_solr+=("${site}")
     continue
   fi
 
   # Rebuild Drupal's caches once per affected site before mutating its indexes.
   if ! drush_for_site "${site}" --yes cache:rebuild; then
     echo "ERROR: ${site}: cache rebuild failed." >&2
-    for index in "${indexes_to_rebuild[@]}"; do
+    for index in "${solr_indexes[@]}"; do
       failed_indexes+=("${site}/${index} (cache rebuild)")
     done
     continue
   fi
 
-  for index in "${indexes_to_rebuild[@]}"; do
-    echo "===== ${site}/${index}: rebuilding for Solr version change ====="
+  for index in "${solr_indexes[@]}"; do
+    echo "===== ${site}/${index}: rebuilding for declared Solr version change ====="
     if ! clear_solr_index "${site}" "${index}" || ! rebuild_solr_index "${site}" "${index}"; then
       echo "ERROR: ${site}/${index}: rebuild failed." >&2
       failed_indexes+=("${site}/${index} (rebuild)")
@@ -367,25 +291,9 @@ for site in "${SITES[@]}"; do
   pause_for "${SITE_PAUSE_SECONDS}"
 done
 
+echo "Solr rebuild complete: ${#rebuilt_indexes[@]} rebuilt, ${#sites_without_solr[@]} sites without Solr indexes, ${#skipped_sites[@]} sites skipped."
+
 if (( ${#failed_indexes[@]} > 0 )); then
   printf 'Failed: %s\n' "${failed_indexes[*]}" >&2
   exit 1
 fi
-
-if [[ "${MODE}" == detect ]]; then
-  if (( ${#detected_versions[@]} == 0 )); then
-    echo "ERROR: No live Solr versions were detected in the source environment." >&2
-    exit 1
-  fi
-  # A single source version is required because CircleCI passes one comparison
-  # value to the target environment. Refuse an ambiguous mixed-version source.
-  mapfile -t unique_versions < <(printf '%s\n' "${detected_versions[@]}" | sort -u)
-  if (( ${#unique_versions[@]} != 1 )); then
-    echo "ERROR: Expected one Solr version across the source environment; found: ${unique_versions[*]:-none}." >&2
-    exit 1
-  fi
-  printf 'DETECTED_SOLR_VERSION\t%s\n' "${unique_versions[0]}"
-  exit 0
-fi
-
-echo "Solr version reconciliation complete: ${#unchanged_indexes[@]} unchanged, ${#rebuilt_indexes[@]} rebuilt, ${#skipped_sites[@]} sites skipped."

--- a/scripts/reconcile-solr-indexes.sh
+++ b/scripts/reconcile-solr-indexes.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
 
-# Compare Drupal's Search API tracker counts with the number of documents that
-# can actually be queried from Solr. Clear and fully rebuild only indexes whose
-# counts differ. Intended to run inside a deployed Platform.sh application.
+# Compare the live Solr version in a data-sync source environment with the
+# version used by each Search API Solr index in the target environment. Rebuild
+# only indexes whose target version differs from the source version.
 
 set -uo pipefail
 
+MODE="${1:-reconcile}"
 APP_ROOT="${PLATFORM_APP_DIR:-/app}"
-SITES_ROOT="${APP_ROOT}/project/sites"
+DRUPAL_ROOT="${DRUPAL_ROOT:-${APP_ROOT}/web}"
+SITES_ROOT="${SITES_ROOT:-}"
+SOURCE_SOLR_VERSION="${SOURCE_SOLR_VERSION:-}"
 INDEX_CHUNK_SIZE="${INDEX_CHUNK_SIZE:-500}"
 INDEX_BATCH_SIZE="${INDEX_BATCH_SIZE:-25}"
 CHUNK_PAUSE_SECONDS="${CHUNK_PAUSE_SECONDS:-5}"
@@ -16,7 +19,17 @@ SITE_PAUSE_SECONDS="${SITE_PAUSE_SECONDS:-20}"
 SOLR_READY_RETRIES="${SOLR_READY_RETRIES:-12}"
 SOLR_READY_DELAY_SECONDS="${SOLR_READY_DELAY_SECONDS:-10}"
 CLEAR_RETRIES="${CLEAR_RETRIES:-3}"
-VERIFY_RETRIES="${VERIFY_RETRIES:-6}"
+
+if [[ "${MODE}" != detect && "${MODE}" != reconcile ]]; then
+  echo "ERROR: Usage: $0 [detect|reconcile]" >&2
+  exit 1
+fi
+
+if [[ "${MODE}" == reconcile ]] &&
+  { [[ ! "${SOURCE_SOLR_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || [[ "${SOURCE_SOLR_VERSION}" == 0.0.0 ]]; }; then
+  echo "ERROR: SOURCE_SOLR_VERSION must be a detected semantic Solr version." >&2
+  exit 1
+fi
 
 if command -v drush >/dev/null 2>&1; then
   DRUSH=(drush)
@@ -27,22 +40,36 @@ else
   exit 1
 fi
 
-if [[ ! -d "${SITES_ROOT}" ]]; then
-  echo "ERROR: Site directory not found: ${SITES_ROOT}" >&2
+if [[ ! -d "${DRUPAL_ROOT}" ]]; then
+  echo "ERROR: Drupal root not found: ${DRUPAL_ROOT}" >&2
+  exit 1
+fi
+
+if [[ -z "${SITES_ROOT}" ]]; then
+  for sites_root_candidate in "${APP_ROOT}/project/sites" "${DRUPAL_ROOT}/sites"; do
+    if [[ -d "${sites_root_candidate}" ]] &&
+      find "${sites_root_candidate}" -mindepth 2 -maxdepth 2 -type f -name settings.php -print -quit | grep -q .; then
+      SITES_ROOT="${sites_root_candidate}"
+      break
+    fi
+  done
+fi
+
+if [[ -z "${SITES_ROOT}" || ! -d "${SITES_ROOT}" ]]; then
+  echo "ERROR: Drupal sites directory was not found under ${APP_ROOT}/project/sites or ${DRUPAL_ROOT}/sites." >&2
   exit 1
 fi
 
 for setting in \
   INDEX_CHUNK_SIZE INDEX_BATCH_SIZE CHUNK_PAUSE_SECONDS INDEX_PAUSE_SECONDS \
-  SITE_PAUSE_SECONDS SOLR_READY_RETRIES SOLR_READY_DELAY_SECONDS CLEAR_RETRIES \
-  VERIFY_RETRIES; do
+  SITE_PAUSE_SECONDS SOLR_READY_RETRIES SOLR_READY_DELAY_SECONDS CLEAR_RETRIES; do
   if [[ ! "${!setting}" =~ ^[0-9]+$ ]]; then
     echo "ERROR: ${setting} must be a non-negative integer." >&2
     exit 1
   fi
 done
 
-if (( INDEX_CHUNK_SIZE == 0 || INDEX_BATCH_SIZE == 0 || SOLR_READY_RETRIES == 0 || CLEAR_RETRIES == 0 || VERIFY_RETRIES == 0 )); then
+if (( INDEX_CHUNK_SIZE == 0 || INDEX_BATCH_SIZE == 0 || SOLR_READY_RETRIES == 0 || CLEAR_RETRIES == 0 )); then
   echo "ERROR: Chunk sizes and retry counts must be greater than zero." >&2
   exit 1
 fi
@@ -57,6 +84,8 @@ if (( ${#SITES[@]} == 0 )); then
   exit 1
 fi
 
+echo "Using Drupal root ${DRUPAL_ROOT} and sites directory ${SITES_ROOT}."
+
 pause_for() {
   local seconds="$1"
   if (( seconds > 0 )); then
@@ -67,7 +96,7 @@ pause_for() {
 drush_for_site() {
   local site="$1"
   shift
-  "${DRUSH[@]}" --root="${APP_ROOT}/web" --uri="${site}" "$@"
+  "${DRUSH[@]}" --root="${DRUPAL_ROOT}" --uri="${site}" "$@"
 }
 
 discover_solr_indexes() {
@@ -83,7 +112,7 @@ discover_solr_indexes() {
   '
 }
 
-get_index_counts() {
+get_solr_version() {
   local site="$1"
   local index="$2"
 
@@ -94,14 +123,10 @@ get_index_counts() {
     if (!$index) {
       throw new \RuntimeException("Search API index was not found.");
     }
-
-    $tracker_count = $index->getTrackerInstance()->getIndexedItemsCount();
-    $query = $index->query();
-    $query->range(0, 0);
-    $query->setOption("search_api_bypass_access", TRUE);
-    $solr_count = $query->execute()->getResultCount();
-    printf("SOLR_COUNTS\t%d\t%d\n", $tracker_count, $solr_count);
-  ' | awk -F '\t' '$1 == "SOLR_COUNTS" { print $2 "\t" $3 }'
+    $backend = $index->getServerInstance()->getBackend();
+    $version = $backend->getSolrConnector()->getSolrVersion(TRUE);
+    printf("SOLR_VERSION\t%s\n", $version);
+  ' | awk -F '\t' '$1 == "SOLR_VERSION" { print $2 }'
 }
 
 get_remaining_items() {
@@ -173,9 +198,8 @@ clear_solr_index() {
     fi
     printf '%s\n' "${clear_output}"
 
-    # Search API can log a backend exception followed by a success message and
-    # still return zero, so inspect the output as well as the exit status.
-    if [[ "${clear_succeeded}" == true ]] && ! grep -qE '\[error\]|SearchApiSolrException|SolrCore is loading' <<< "${clear_output}"; then
+    if [[ "${clear_succeeded}" == true ]] &&
+      ! grep -qE 'SearchApiSolrException|SolrCore is loading|Solr HTTP error|Solr endpoint .*unreachable' <<< "${clear_output}"; then
       return 0
     fi
 
@@ -199,11 +223,9 @@ rebuild_solr_index() {
     if ! before=$(get_remaining_items "${site}" "${index}"); then
       return 1
     fi
-
     if (( before == 0 )); then
       return 0
     fi
-
     if ! wait_for_solr_index "${site}" "${index}"; then
       return 1
     fi
@@ -219,7 +241,6 @@ rebuild_solr_index() {
     if ! after=$(get_remaining_items "${site}" "${index}"); then
       return 1
     fi
-
     if (( after >= before )); then
       (( stalled_attempts++ ))
       if (( stalled_attempts >= 3 )); then
@@ -229,133 +250,96 @@ rebuild_solr_index() {
     else
       stalled_attempts=0
     fi
-
     if (( after > 0 )); then
       pause_for "${CHUNK_PAUSE_SECONDS}"
     fi
   done
 }
 
-verify_alignment() {
-  local site="$1"
-  local index="$2"
-  local attempt
-  local counts
-  local tracker_count
-  local solr_count
-
-  for (( attempt = 1; attempt <= VERIFY_RETRIES; attempt++ )); do
-    if counts=$(get_index_counts "${site}" "${index}"); then
-      IFS=$'\t' read -r tracker_count solr_count <<< "${counts}"
-      if [[ "${tracker_count}" =~ ^[0-9]+$ && "${solr_count}" =~ ^[0-9]+$ && "${tracker_count}" -eq "${solr_count}" ]]; then
-        echo "${site}/${index}: verified ${solr_count} documents in Solr."
-        return 0
-      fi
-    fi
-
-    if (( attempt < VERIFY_RETRIES )); then
-      echo "${site}/${index}: counts have not converged; waiting ${SOLR_READY_DELAY_SECONDS}s."
-      pause_for "${SOLR_READY_DELAY_SECONDS}"
-    fi
-  done
-
-  echo "ERROR: ${site}/${index}: tracker count ${tracker_count:-unknown} does not match Solr count ${solr_count:-unknown}." >&2
-  return 1
-}
-
+detected_versions=()
 failed_indexes=()
 rebuilt_indexes=()
-aligned_indexes=()
+unchanged_indexes=()
 skipped_sites=()
 
-echo "Checking Drupal tracker counts against live Solr counts across ${#SITES[@]} sites."
-
 for site in "${SITES[@]}"; do
-  echo
-  echo "===== ${site}: checking Solr indexes ====="
-
   if ! index_output=$(discover_solr_indexes "${site}" 2>&1); then
-    echo "NOTICE: ${site}: Drupal did not bootstrap; skipping."
+    echo "NOTICE: ${site}: Drupal did not bootstrap; skipping." >&2
     skipped_sites+=("${site}")
     continue
   fi
 
   mapfile -t solr_indexes < <(awk -F '\t' '$1 == "SOLR_INDEX" { print $2 }' <<< "${index_output}")
   if (( ${#solr_indexes[@]} == 0 )); then
-    echo "No enabled Solr indexes found; skipping ${site}."
-    skipped_sites+=("${site}")
     continue
   fi
 
-  mismatched_indexes=()
+  indexes_to_rebuild=()
   for index in "${solr_indexes[@]}"; do
-    if ! counts=$(get_index_counts "${site}" "${index}"); then
-      echo "ERROR: ${site}/${index}: could not query tracker and Solr counts." >&2
-      failed_indexes+=("${site}/${index} (count check)")
+    if ! target_version=$(get_solr_version "${site}" "${index}") ||
+      [[ ! "${target_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ || "${target_version}" == 0.0.0 ]]; then
+      echo "ERROR: ${site}/${index}: could not detect a live Solr version." >&2
+      failed_indexes+=("${site}/${index} (version detection)")
       continue
     fi
 
-    IFS=$'\t' read -r tracker_count solr_count <<< "${counts}"
-    if [[ ! "${tracker_count}" =~ ^[0-9]+$ || ! "${solr_count}" =~ ^[0-9]+$ ]]; then
-      echo "ERROR: ${site}/${index}: invalid counts: tracker=${tracker_count:-unknown}, Solr=${solr_count:-unknown}." >&2
-      failed_indexes+=("${site}/${index} (invalid counts)")
-      continue
-    fi
-
-    if (( tracker_count == solr_count )); then
-      echo "${site}/${index}: aligned at ${solr_count} documents."
-      aligned_indexes+=("${site}/${index}")
+    if [[ "${MODE}" == detect ]]; then
+      detected_versions+=("${target_version}")
+    elif [[ "${target_version}" == "${SOURCE_SOLR_VERSION}" ]]; then
+      echo "${site}/${index}: Solr ${target_version} matches the source environment; no rebuild needed."
+      unchanged_indexes+=("${site}/${index}")
     else
-      echo "${site}/${index}: mismatch detected (tracker=${tracker_count}, Solr=${solr_count}); scheduling a full rebuild."
-      mismatched_indexes+=("${index}")
+      echo "${site}/${index}: source Solr=${SOURCE_SOLR_VERSION}, target Solr=${target_version}; scheduling rebuild."
+      indexes_to_rebuild+=("${index}")
     fi
   done
 
-  if (( ${#mismatched_indexes[@]} == 0 )); then
+  if [[ "${MODE}" == detect ]] || (( ${#indexes_to_rebuild[@]} == 0 )); then
     continue
   fi
 
   if ! drush_for_site "${site}" --yes cache:rebuild; then
-    echo "ERROR: ${site}: cache rebuild failed; mismatched indexes were not rebuilt." >&2
-    for index in "${mismatched_indexes[@]}"; do
+    echo "ERROR: ${site}: cache rebuild failed." >&2
+    for index in "${indexes_to_rebuild[@]}"; do
       failed_indexes+=("${site}/${index} (cache rebuild)")
     done
     continue
   fi
 
-  for index in "${mismatched_indexes[@]}"; do
-    echo "===== ${site}/${index}: clearing mismatched index ====="
-    if ! clear_solr_index "${site}" "${index}"; then
-      echo "ERROR: ${site}/${index}: clear failed." >&2
-      failed_indexes+=("${site}/${index} (clear)")
-      pause_for "${INDEX_PAUSE_SECONDS}"
-      continue
-    fi
-
-    echo "===== ${site}/${index}: rebuilding full index ====="
-    if ! rebuild_solr_index "${site}" "${index}"; then
+  for index in "${indexes_to_rebuild[@]}"; do
+    echo "===== ${site}/${index}: rebuilding for Solr version change ====="
+    if ! clear_solr_index "${site}" "${index}" || ! rebuild_solr_index "${site}" "${index}"; then
       echo "ERROR: ${site}/${index}: rebuild failed." >&2
       failed_indexes+=("${site}/${index} (rebuild)")
-      pause_for "${INDEX_PAUSE_SECONDS}"
-      continue
-    fi
-
-    if verify_alignment "${site}" "${index}"; then
+    elif [[ "$(get_remaining_items "${site}" "${index}")" == 0 ]]; then
       rebuilt_indexes+=("${site}/${index}")
     else
+      echo "ERROR: ${site}/${index}: tracker items remain after rebuild." >&2
       failed_indexes+=("${site}/${index} (verification)")
     fi
-
     pause_for "${INDEX_PAUSE_SECONDS}"
   done
 
   pause_for "${SITE_PAUSE_SECONDS}"
 done
 
-echo
-echo "Solr reconciliation complete: ${#aligned_indexes[@]} already aligned, ${#rebuilt_indexes[@]} rebuilt, ${#skipped_sites[@]} sites skipped, ${#failed_indexes[@]} failures."
-
 if (( ${#failed_indexes[@]} > 0 )); then
   printf 'Failed: %s\n' "${failed_indexes[*]}" >&2
   exit 1
 fi
+
+if [[ "${MODE}" == detect ]]; then
+  if (( ${#detected_versions[@]} == 0 )); then
+    echo "ERROR: No live Solr versions were detected in the source environment." >&2
+    exit 1
+  fi
+  mapfile -t unique_versions < <(printf '%s\n' "${detected_versions[@]}" | sort -u)
+  if (( ${#unique_versions[@]} != 1 )); then
+    echo "ERROR: Expected one Solr version across the source environment; found: ${unique_versions[*]:-none}." >&2
+    exit 1
+  fi
+  printf 'DETECTED_SOLR_VERSION\t%s\n' "${unique_versions[0]}"
+  exit 0
+fi
+
+echo "Solr version reconciliation complete: ${#unchanged_indexes[@]} unchanged, ${#rebuilt_indexes[@]} rebuilt, ${#skipped_sites[@]} sites skipped."

--- a/scripts/tests/reconcile-solr-indexes.sh
+++ b/scripts/tests/reconcile-solr-indexes.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPOSITORY_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_UNDER_TEST="${REPOSITORY_ROOT}/scripts/reconcile-solr-indexes.sh"
+TEST_ROOT="$(mktemp -d)"
+
+trap 'rm -rf "${TEST_ROOT}"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+mkdir -p "${TEST_ROOT}/bin"
+cat > "${TEST_ROOT}/bin/drush" <<'MOCK_DRUSH'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+state="$(< "${MOCK_STATE_FILE}")"
+command_line="$*"
+
+if [[ "${command_line}" == *'loadMultiple()'* ]]; then
+  printf 'SOLR_INDEX\tdefault_index\n'
+elif [[ "${command_line}" == *'getSolrVersion(TRUE)'* ]]; then
+  printf 'SOLR_VERSION\t%s\n' "${MOCK_TARGET_VERSION}"
+elif [[ "${command_line}" == *'getRemainingItemsCount()'* ]]; then
+  if [[ "${state}" == cleared ]]; then
+    printf '%s\n' "${MOCK_ITEMS_AFTER_CLEAR}"
+  else
+    printf '0\n'
+  fi
+elif [[ "${command_line}" == *'isAvailable()'* ]]; then
+  exit 0
+elif [[ "${command_line}" == *'search-api:clear'* ]]; then
+  printf 'cleared\n' > "${MOCK_STATE_FILE}"
+  echo '[error] Fastly service ID is absent on this edge environment.'
+  echo '[success] Index was successfully cleared.'
+elif [[ "${command_line}" == *'search-api:index'* ]]; then
+  printf 'indexed\n' > "${MOCK_STATE_FILE}"
+  echo '[success] Tracker items were processed.'
+elif [[ "${command_line}" == *'cache:rebuild'* ]]; then
+  echo '[success] Cache rebuild complete.'
+else
+  echo "Unexpected mock Drush command: ${command_line}" >&2
+  exit 1
+fi
+MOCK_DRUSH
+chmod +x "${TEST_ROOT}/bin/drush"
+
+create_app() {
+  local app_root="$1"
+  local layout="$2"
+
+  mkdir -p "${app_root}/web"
+  if [[ "${layout}" == project ]]; then
+    mkdir -p "${app_root}/project/sites/example"
+    touch "${app_root}/project/sites/example/settings.php"
+  else
+    mkdir -p "${app_root}/web/sites/default"
+    touch "${app_root}/web/sites/default/settings.php"
+  fi
+}
+
+run_reconcile_case() {
+  local name="$1"
+  local layout="$2"
+  local source_version="$3"
+  local target_version="$4"
+  local expected_output="$5"
+  local expected_state="$6"
+  local app_root="${TEST_ROOT}/${name}/app"
+  local state_file="${TEST_ROOT}/${name}/state"
+  local output
+
+  create_app "${app_root}" "${layout}"
+  printf 'initial\n' > "${state_file}"
+
+  if ! output=$(
+    PATH="${TEST_ROOT}/bin:${PATH}" \
+    PLATFORM_APP_DIR="${app_root}" \
+    SOURCE_SOLR_VERSION="${source_version}" \
+    MOCK_STATE_FILE="${state_file}" \
+    MOCK_TARGET_VERSION="${target_version}" \
+    MOCK_ITEMS_AFTER_CLEAR=10 \
+    CHUNK_PAUSE_SECONDS=0 \
+    INDEX_PAUSE_SECONDS=0 \
+    SITE_PAUSE_SECONDS=0 \
+    SOLR_READY_DELAY_SECONDS=0 \
+    bash "${SCRIPT_UNDER_TEST}" reconcile 2>&1
+  ); then
+    echo "${output}" >&2
+    fail "${name} returned a failure status"
+  fi
+
+  [[ "${output}" == *"${expected_output}"* ]] || {
+    echo "${output}" >&2
+    fail "${name} did not contain expected output: ${expected_output}"
+  }
+  [[ "$(< "${state_file}")" == "${expected_state}" ]] ||
+    fail "${name} ended in state $(< "${state_file}"); expected ${expected_state}"
+}
+
+run_detect_case() {
+  local app_root="${TEST_ROOT}/detect/app"
+  local state_file="${TEST_ROOT}/detect/state"
+  local output
+
+  create_app "${app_root}" project
+  printf 'initial\n' > "${state_file}"
+  output=$(
+    PATH="${TEST_ROOT}/bin:${PATH}" \
+    PLATFORM_APP_DIR="${app_root}" \
+    MOCK_STATE_FILE="${state_file}" \
+    MOCK_TARGET_VERSION=9.9.0 \
+    MOCK_ITEMS_AFTER_CLEAR=10 \
+    bash "${SCRIPT_UNDER_TEST}" detect
+  )
+  [[ "${output}" == *$'DETECTED_SOLR_VERSION\t9.9.0'* ]] ||
+    fail "detect mode did not emit the source version"
+  [[ "$(< "${state_file}")" == initial ]] ||
+    fail "detect mode mutated the index"
+}
+
+run_detect_case
+
+run_reconcile_case \
+  web_sites_matching_version web \
+  8.11.2 8.11.2 \
+  'matches the source environment; no rebuild needed' initial
+
+run_reconcile_case \
+  project_sites_changed_version project \
+  9.8.0 9.9.0 \
+  'rebuilding for Solr version change' indexed
+
+echo 'reconcile-solr-indexes tests passed.'

--- a/scripts/tests/reconcile-solr-indexes.sh
+++ b/scripts/tests/reconcile-solr-indexes.sh
@@ -23,9 +23,9 @@ state="$(< "${MOCK_STATE_FILE}")"
 command_line="$*"
 
 if [[ "${command_line}" == *'loadMultiple()'* ]]; then
-  printf 'SOLR_INDEX\tdefault_index\n'
-elif [[ "${command_line}" == *'getSolrVersion(TRUE)'* ]]; then
-  printf 'SOLR_VERSION\t%s\n' "${MOCK_TARGET_VERSION}"
+  if [[ "${MOCK_HAS_SOLR_INDEX}" == true ]]; then
+    printf 'SOLR_INDEX\tdefault_index\n'
+  fi
 elif [[ "${command_line}" == *'getRemainingItemsCount()'* ]]; then
   if [[ "${state}" == cleared ]]; then
     printf '%s\n' "${MOCK_ITEMS_AFTER_CLEAR}"
@@ -64,13 +64,12 @@ create_app() {
   fi
 }
 
-run_reconcile_case() {
+run_case() {
   local name="$1"
   local layout="$2"
-  local source_version="$3"
-  local target_version="$4"
-  local expected_output="$5"
-  local expected_state="$6"
+  local has_solr_index="$3"
+  local expected_output="$4"
+  local expected_state="$5"
   local app_root="${TEST_ROOT}/${name}/app"
   local state_file="${TEST_ROOT}/${name}/state"
   local output
@@ -81,15 +80,14 @@ run_reconcile_case() {
   if ! output=$(
     PATH="${TEST_ROOT}/bin:${PATH}" \
     PLATFORM_APP_DIR="${app_root}" \
-    SOURCE_SOLR_VERSION="${source_version}" \
     MOCK_STATE_FILE="${state_file}" \
-    MOCK_TARGET_VERSION="${target_version}" \
+    MOCK_HAS_SOLR_INDEX="${has_solr_index}" \
     MOCK_ITEMS_AFTER_CLEAR=10 \
     CHUNK_PAUSE_SECONDS=0 \
     INDEX_PAUSE_SECONDS=0 \
     SITE_PAUSE_SECONDS=0 \
     SOLR_READY_DELAY_SECONDS=0 \
-    bash "${SCRIPT_UNDER_TEST}" reconcile 2>&1
+    bash "${SCRIPT_UNDER_TEST}" 2>&1
   ); then
     echo "${output}" >&2
     fail "${name} returned a failure status"
@@ -103,37 +101,12 @@ run_reconcile_case() {
     fail "${name} ended in state $(< "${state_file}"); expected ${expected_state}"
 }
 
-run_detect_case() {
-  local app_root="${TEST_ROOT}/detect/app"
-  local state_file="${TEST_ROOT}/detect/state"
-  local output
+run_case \
+  web_site_without_solr web false \
+  'no enabled Search API Solr indexes; skipping' initial
 
-  create_app "${app_root}" project
-  printf 'initial\n' > "${state_file}"
-  output=$(
-    PATH="${TEST_ROOT}/bin:${PATH}" \
-    PLATFORM_APP_DIR="${app_root}" \
-    MOCK_STATE_FILE="${state_file}" \
-    MOCK_TARGET_VERSION=9.9.0 \
-    MOCK_ITEMS_AFTER_CLEAR=10 \
-    bash "${SCRIPT_UNDER_TEST}" detect
-  )
-  [[ "${output}" == *$'DETECTED_SOLR_VERSION\t9.9.0'* ]] ||
-    fail "detect mode did not emit the source version"
-  [[ "$(< "${state_file}")" == initial ]] ||
-    fail "detect mode mutated the index"
-}
-
-run_detect_case
-
-run_reconcile_case \
-  web_sites_matching_version web \
-  8.11.2 8.11.2 \
-  'matches the source environment; no rebuild needed' initial
-
-run_reconcile_case \
-  project_sites_changed_version project \
-  9.8.0 9.9.0 \
-  'rebuilding for Solr version change' indexed
+run_case \
+  project_site_with_solr project true \
+  'rebuilding for declared Solr version change' indexed
 
 echo 'reconcile-solr-indexes tests passed.'

--- a/shared-config.yml
+++ b/shared-config.yml
@@ -712,22 +712,47 @@ jobs:
 
 commands:
   reconcile_solr_indexes:
-    description: "Rebuild Search API Solr indexes when Drupal tracker and live document counts differ"
+    description: "Rebuild Search API Solr indexes when source and target environments use different Solr versions"
     steps:
       - run:
-          name: Reconcile Drupal tracker counts with live Solr indexes
+          name: Rebuild edge indexes when the live Solr version differs from the source
           shell: /bin/bash -euo pipefail
           command: |
             script_path="/tmp/reconcile-solr-indexes.sh"
             script_url="https://raw.githubusercontent.com/dof-dss/webdev-ci/main/scripts/reconcile-solr-indexes.sh?nocache=$(date +%s)"
+            script_sha256="9f10b5d4bc94e2b8498104c4a7643f21d7cbb54278565de9f9d6999ccd4a51fe"
 
             curl --fail --location --silent --show-error "${script_url}" --output "${script_path}"
+            printf '%s  %s\n' "${script_sha256}" "${script_path}" | sha256sum --check --status || {
+              echo "ERROR: Downloaded Solr reconciliation script does not match the shared CI config." >&2
+              exit 1
+            }
             chmod +x "${script_path}"
+
+            source_environment=$(platform environment:info parent \
+              --project "${PLATFORM_PROJECT}" \
+              --environment "${EDGE_BUILD_BRANCH}" \
+              --format plain)
+            if [[ -z "${source_environment}" || "${source_environment}" == "-" ]]; then
+              echo "ERROR: Could not determine the data-sync source environment for ${EDGE_BUILD_BRANCH}." >&2
+              exit 1
+            fi
+
+            source_output=$(platform ssh \
+              --project "${PLATFORM_PROJECT}" \
+              --environment "${source_environment}" \
+              -- bash -s -- detect < "${script_path}")
+            printf '%s\n' "${source_output}"
+            source_solr_version=$(awk -F '\t' '$1 == "DETECTED_SOLR_VERSION" { print $2 }' <<< "${source_output}")
+            if [[ ! "${source_solr_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "ERROR: Could not detect a single Solr version in source environment ${source_environment}." >&2
+              exit 1
+            fi
 
             platform ssh \
               --project "${PLATFORM_PROJECT}" \
               --environment "${EDGE_BUILD_BRANCH}" \
-              -- bash -s < "${script_path}"
+              -- env SOURCE_SOLR_VERSION="${source_solr_version}" bash -s -- reconcile < "${script_path}"
           no_output_timeout: 30m
 
   checkout_code:

--- a/shared-config.yml
+++ b/shared-config.yml
@@ -712,25 +712,12 @@ jobs:
 
 commands:
   reconcile_solr_indexes:
-    description: "Rebuild Search API Solr indexes when source and target environments use different Solr versions"
+    description: "Rebuild Search API Solr indexes when source and target environments declare different Solr versions"
     steps:
       - run:
-          name: Rebuild edge indexes when the live Solr version differs from the source
+          name: Rebuild edge indexes when the declared Solr version differs from the source
           shell: /bin/bash -euo pipefail
           command: |
-            script_path="/tmp/reconcile-solr-indexes.sh"
-            script_url="https://raw.githubusercontent.com/dof-dss/webdev-ci/main/scripts/reconcile-solr-indexes.sh?nocache=$(date +%s)"
-            script_sha256="7ca35b8de3479bd95fe1a66b48243665789237ab150d557eec6c36331d2f2500"
-
-            # Pin the helper to the exact content reviewed with this shared
-            # configuration. This prevents main moving between the two fetches.
-            curl --fail --location --silent --show-error "${script_url}" --output "${script_path}"
-            printf '%s  %s\n' "${script_sha256}" "${script_path}" | sha256sum --check --status || {
-              echo "ERROR: Downloaded Solr reconciliation script does not match the shared CI config." >&2
-              exit 1
-            }
-            chmod +x "${script_path}"
-
             # platform sync data uses the edge environment's parent as its
             # source. Detect that parent rather than assuming a branch name.
             source_environment=$(platform environment:info parent \
@@ -742,25 +729,63 @@ commands:
               exit 1
             fi
 
-            # Detection is read-only and emits a tab-delimited marker amongst
-            # normal Drush output for reliable extraction below.
-            source_output=$(platform ssh \
-              --project "${PLATFORM_PROJECT}" \
-              --environment "${source_environment}" \
-              -- bash -s -- detect < "${script_path}")
-            printf '%s\n' "${source_output}"
-            source_solr_version=$(awk -F '\t' '$1 == "DETECTED_SOLR_VERSION" { print $2 }' <<< "${source_output}")
-            if [[ ! "${source_solr_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "ERROR: Could not detect a single Solr version in source environment ${source_environment}." >&2
+            # Read the service declarations deployed to each environment. The
+            # command returns an empty value when an environment has no Solr
+            # service and rejects ambiguous projects with multiple versions.
+            declared_solr_version() {
+              local environment="$1"
+              local service_types
+              local -a versions
+
+              if ! service_types=$(platform services \
+                --project "${PLATFORM_PROJECT}" \
+                --environment "${environment}" \
+                --columns type \
+                --format tsv \
+                --no-header); then
+                echo "ERROR: Could not read services for environment ${environment}." >&2
+                return 1
+              fi
+              mapfile -t versions < <(
+                awk -F '\t' '$1 ~ /^solr:[0-9]+([.][0-9]+)*$/ { sub(/^solr:/, "", $1); print $1 }' <<< "${service_types}" | sort -u
+              )
+
+              if (( ${#versions[@]} > 1 )); then
+                echo "ERROR: Environment ${environment} declares multiple Solr versions: ${versions[*]}." >&2
+                return 1
+              fi
+              printf '%s\n' "${versions[0]:-}"
+            }
+
+            if ! source_solr_version=$(declared_solr_version "${source_environment}"); then
+              exit 1
+            fi
+            if ! target_solr_version=$(declared_solr_version "${EDGE_BUILD_BRANCH}"); then
               exit 1
             fi
 
-            # Reconciliation runs only in the edge environment. The helper
-            # leaves every index untouched when its live version matches.
+            if [[ -z "${target_solr_version}" ]]; then
+              echo "No Solr service is declared for ${EDGE_BUILD_BRANCH}; skipping index rebuild."
+              exit 0
+            fi
+            if [[ "${source_solr_version}" == "${target_solr_version}" ]]; then
+              echo "Source and target both declare Solr ${target_solr_version}; no index rebuild needed."
+              exit 0
+            fi
+
+            echo "Declared Solr version changed: source=${source_solr_version:-none}, target=${target_solr_version}."
+
+            # Fetch the current helper from main only when a rebuild is needed.
+            # This repository intentionally follows the latest HEAD version.
+            script_path="/tmp/reconcile-solr-indexes.sh"
+            script_url="https://raw.githubusercontent.com/dof-dss/webdev-ci/main/scripts/reconcile-solr-indexes.sh?nocache=$(date +%s)"
+            curl --fail --location --silent --show-error "${script_url}" --output "${script_path}"
+            chmod +x "${script_path}"
+
             platform ssh \
               --project "${PLATFORM_PROJECT}" \
               --environment "${EDGE_BUILD_BRANCH}" \
-              -- env SOURCE_SOLR_VERSION="${source_solr_version}" bash -s -- reconcile < "${script_path}"
+              -- bash -s < "${script_path}"
           no_output_timeout: 30m
 
   checkout_code:

--- a/shared-config.yml
+++ b/shared-config.yml
@@ -720,8 +720,10 @@ commands:
           command: |
             script_path="/tmp/reconcile-solr-indexes.sh"
             script_url="https://raw.githubusercontent.com/dof-dss/webdev-ci/main/scripts/reconcile-solr-indexes.sh?nocache=$(date +%s)"
-            script_sha256="9f10b5d4bc94e2b8498104c4a7643f21d7cbb54278565de9f9d6999ccd4a51fe"
+            script_sha256="7ca35b8de3479bd95fe1a66b48243665789237ab150d557eec6c36331d2f2500"
 
+            # Pin the helper to the exact content reviewed with this shared
+            # configuration. This prevents main moving between the two fetches.
             curl --fail --location --silent --show-error "${script_url}" --output "${script_path}"
             printf '%s  %s\n' "${script_sha256}" "${script_path}" | sha256sum --check --status || {
               echo "ERROR: Downloaded Solr reconciliation script does not match the shared CI config." >&2
@@ -729,6 +731,8 @@ commands:
             }
             chmod +x "${script_path}"
 
+            # platform sync data uses the edge environment's parent as its
+            # source. Detect that parent rather than assuming a branch name.
             source_environment=$(platform environment:info parent \
               --project "${PLATFORM_PROJECT}" \
               --environment "${EDGE_BUILD_BRANCH}" \
@@ -738,6 +742,8 @@ commands:
               exit 1
             fi
 
+            # Detection is read-only and emits a tab-delimited marker amongst
+            # normal Drush output for reliable extraction below.
             source_output=$(platform ssh \
               --project "${PLATFORM_PROJECT}" \
               --environment "${source_environment}" \
@@ -749,6 +755,8 @@ commands:
               exit 1
             fi
 
+            # Reconciliation runs only in the edge environment. The helper
+            # leaves every index untouched when its live version matches.
             platform ssh \
               --project "${PLATFORM_PROJECT}" \
               --environment "${EDGE_BUILD_BRANCH}" \


### PR DESCRIPTION
## Summary

- detect the live Solr version in the data-sync source environment
- rebuild edge Search API indexes only when the target Solr version differs
- support both project/sites and web/sites layouts without hard-coded project versions
- add focused regression coverage and document local execution

## Validation

- bash syntax validation for the reconciliation script and test harness
- focused detection, matching-version, and changed-version regression scenarios
- shared CircleCI command shell syntax validation
- shared-config.yml YAML parsing
- downloaded-script checksum verification
- git diff --cached --check