### PR TITLE
Drop the need to reconcile solr indexes on edge environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
             echo '    jobs:' >> temp_config.yml
             # Use your known defaults for the parameters:
             echo '      - build: {php_version: "8.3", ssh_fingerprint: ""}' >> temp_config.yml
-            # Exercise both edge-finalisation paths so reusable commands are compiled.
+            # Compile both edge-finalisation paths.
             echo '      - sync_data: {edge_branch: "edge", php_version: "8.3"}' >> temp_config.yml
             echo '      - unity_sync_data: {edge_branch: "edge", php_version: "8.3"}' >> temp_config.yml
 

--- a/README.md
+++ b/README.md
@@ -60,48 +60,23 @@ jobs:
 - YAML anchors can't be preprocessed with pipeline parameters (yet), so you'll see these re-declared to prioritise parameter usage over lack of repetition.
 - There's a preprocess/setup step involved now where a continuation orb will take the central config file, and preprocess it into a final YAML file which is then executed in the usual workflow steps.
 
-## Edge Solr version reconciliation
+## Manual Solr bulk reconciliation
 
-The shared edge-finalisation jobs run `scripts/reconcile-solr-indexes.sh` after
-the data sync. The CircleCI command detects the edge environment's parent,
-reads the Solr service types declared for the source and edge environments, and
-only runs the helper when those declared versions differ.
+Nightly edge-finalisation jobs do not rebuild Search API Solr indexes. Bulk
+reconciliation is deliberately a developer-run operation because its duration
+and resource cost vary substantially with service allocation, site count, and
+content volume.
 
-This is needed because `platform sync data` copies Drupal's database and files,
-but the source and edge environments can have different Solr service versions.
-The copied database includes Search API tracker state, while the edge Solr index
-remains a separate service. When versions differ, rebuilding makes the tracker
-and index reflect work performed against the edge service. Tracker and document
-counts are deliberately not used: Search API processors can reject documents
-while still marking them processed, so unequal counts are not by themselves
-evidence of a broken index.
+The retained `scripts/reconcile-solr-indexes.sh` helper discovers enabled Search
+API Solr indexes and supports throttled full rebuilds or non-destructive resume
+runs. Stream it into a deliberately selected Upsun SSH session from a developer
+terminal; do not run it against an environment until the target and mode have
+been checked.
 
-### Execution flow
-
-1. CircleCI asks Platform.sh for the edge environment's parent—the same
-   environment used as the data-sync source.
-2. It uses `platform services` to read the service types deployed to the source
-   and edge environments. DDEV configuration is not used for this production
-   decision.
-3. If the edge declares no Solr service, or both environments declare the same
-   Solr version, the command exits successfully without bootstrapping Drupal.
-4. If the edge declares a different Solr version, CircleCI downloads the latest
-   helper from `webdev-ci/main` and runs it only in the edge environment.
-5. The helper discovers enabled Search API Solr indexes. Each affected site
-   receives one Drupal cache rebuild followed by a clear and throttled rebuild.
-   Transient Solr timeouts are retried from the remaining Search API tracker
-   state, without clearing partial progress. Sites without an enabled Solr
-   index are logged and skipped.
-
-If source and edge intentionally remain on different Solr versions, the edge
-indexes are rebuilt after every data sync. This is intentional: each sync
-refreshes Drupal's database and tracker state from that differently versioned
-source environment.
-
-The command fails rather than guessing if the source environment cannot be
-identified, an environment declares multiple Solr service versions, an affected
-site cannot reach Solr after the bounded retry window, clearing fails, indexing
-stops making progress, or Drush reports a deterministic non-Solr error.
+`platform sync data` copies Drupal's database and files, including Search API
+tracker state, but the target Solr index remains a separate service. A developer
+should therefore assess tracker state, target service capacity, and whether a
+clear is actually required before choosing `rebuild` or `resume`.
 
 The script supports both repository layouts used by the consuming projects:
 
@@ -114,8 +89,7 @@ version is hard-coded in the shared configuration.
 
 ### Local debugging
 
-The helper is rebuild-only because CircleCI makes the version decision before
-invoking it. Running it directly in DDEV therefore clears and rebuilds every
+Running the helper in its default `rebuild` mode clears and rebuilds every
 enabled local Search API Solr index. Use a disposable local index:
 
 ```bash
@@ -130,23 +104,18 @@ ddev exec env \
 ```
 
 Use `bash -x -s` instead of `bash -s` to trace commands during local debugging.
-There is no dry-run mode in the helper. To inspect the declared Upsun versions
-without rebuilding, use `platform services --columns type` for the source and
-edge environments.
+There is no dry-run mode in the helper. Inspect the target environment and its
+Search API tracker state separately before running it.
 
-### Recovering an interrupted edge rebuild
+### Running against Upsun
 
 The helper also has a non-destructive `resume` mode. It does not clear an index;
 it continues whatever items are already marked as remaining in the Search API
 tracker. Exact site and index filters keep recovery scoped to the failed work.
 
-Download the helper locally, then run it through the Upsun CLI:
+From a local `webdev-ci` checkout, stream the helper through the Upsun CLI:
 
 ```bash
-curl --fail --location --silent --show-error \
-  https://raw.githubusercontent.com/dof-dss/webdev-ci/main/scripts/reconcile-solr-indexes.sh \
-  --output /tmp/reconcile-solr-indexes.sh
-
 upsun ssh -p "$PLATFORM_PROJECT" -e edge -- env \
   RECONCILE_MODE=resume \
   SITE_FILTER=communityrelations \
@@ -155,7 +124,7 @@ upsun ssh -p "$PLATFORM_PROJECT" -e edge -- env \
   INDEX_BATCH_SIZE=5 \
   CHUNK_PAUSE_SECONDS=20 \
   INDEX_RETRY_DELAY_SECONDS=90 \
-  bash -s < /tmp/reconcile-solr-indexes.sh
+  bash -s < scripts/reconcile-solr-indexes.sh
 ```
 
 Omit `INDEX_FILTER` to resume all enabled Solr indexes for the selected site.
@@ -177,7 +146,7 @@ services:
 - `INDEX_RETRIES=5` and `INDEX_RETRY_DELAY_SECONDS=60` retry known transient
   Solr failures. If a timed-out call made tracker progress, the helper cools
   down and resumes from the new remaining count rather than clearing again.
-- `RECONCILE_MODE=rebuild` is the nightly default. `RECONCILE_MODE=resume`,
+- `RECONCILE_MODE=rebuild` is the script default. `RECONCILE_MODE=resume`,
   `SITE_FILTER`, and `INDEX_FILTER` provide targeted manual recovery.
 
 These values can be overridden as environment variables. Pause values may be

--- a/scripts/reconcile-solr-indexes.sh
+++ b/scripts/reconcile-solr-indexes.sh
@@ -1,14 +1,12 @@
 #!/usr/bin/env bash
 
-# Rebuild enabled Search API Solr indexes in an edge environment.
+# Manually reconcile enabled Search API Solr indexes in an Upsun environment.
 #
-# CircleCI compares the Solr service types declared by the data-sync source and
-# target Upsun environments before invoking this helper. It does not invoke the
-# script when the target has no Solr service or when the declared versions
-# match. Keeping that decision in shared-config.yml means this script only needs
-# to perform one job: safely reconcile the target indexes after a version
-# change. The default mode clears and rebuilds indexes; resume mode continues
-# tracker work without clearing already indexed documents.
+# The script is designed to be streamed from a developer's terminal into an
+# Upsun SSH session. The default mode clears and rebuilds indexes; resume mode
+# continues tracker work without clearing already indexed documents. The caller
+# is responsible for selecting the intended project, environment, mode, site,
+# and index because nightly CI does not invoke this helper.
 #
 # Sites without an enabled Search API Solr index are logged and skipped. This
 # supports multisite projects where only some sites use search as well as
@@ -353,7 +351,7 @@ for site in "${SITES[@]}"; do
   fi
 
   for index in "${solr_indexes[@]}"; do
-    echo "===== ${site}/${index}: ${RECONCILE_MODE} for declared Solr version change ====="
+    echo "===== ${site}/${index}: ${RECONCILE_MODE} requested manually ====="
     operation_failed=false
     if [[ "${RECONCILE_MODE}" == rebuild ]] && ! clear_solr_index "${site}" "${index}"; then
       operation_failed=true

--- a/scripts/tests/reconcile-solr-indexes.sh
+++ b/scripts/tests/reconcile-solr-indexes.sh
@@ -131,7 +131,7 @@ run_case \
 
 run_case \
   project_site_with_solr project true \
-  'rebuild for declared Solr version change' 0
+  'rebuild requested manually' 0
 
 run_case \
   transient_timeout_with_progress project true \
@@ -143,7 +143,7 @@ run_case \
 
 run_case \
   resume_without_clear project true \
-  'resume for declared Solr version change' 0 resume false example default_index
+  'resume requested manually' 0 resume false example default_index
 
 resume_log="${TEST_ROOT}/resume_without_clear/commands"
 if grep -q 'search-api:clear' "${resume_log}"; then

--- a/shared-config.yml
+++ b/shared-config.yml
@@ -164,7 +164,6 @@ jobs:
           name: Reset QA account passwords
           command: |
             platform environment:drush password_qa_accounts -e $EDGE_BUILD_BRANCH
-      - reconcile_solr_indexes
 
   coding_standards:
     shell: /bin/bash -euo pipefail
@@ -643,7 +642,6 @@ jobs:
                 platform drush "bulk_update_qa_accounts enable -l ${site}" -y -p $PLATFORM_PROJECT -e $EDGE_BUILD_BRANCH
               fi
             done
-      - reconcile_solr_indexes
 
   # THEMING repo jobs.
   theme_install:
@@ -711,84 +709,6 @@ jobs:
           command: npm run build
 
 commands:
-  reconcile_solr_indexes:
-    description: "Safely reconcile Search API Solr indexes when source and target environments declare different Solr versions"
-    steps:
-      - run:
-          name: Reconcile edge indexes when the declared Solr version differs from the source
-          shell: /bin/bash -euo pipefail
-          command: |
-            # platform sync data uses the edge environment's parent as its
-            # source. Detect that parent rather than assuming a branch name.
-            source_environment=$(platform environment:info parent \
-              --project "${PLATFORM_PROJECT}" \
-              --environment "${EDGE_BUILD_BRANCH}" \
-              --format plain)
-            if [[ -z "${source_environment}" || "${source_environment}" == "-" ]]; then
-              echo "ERROR: Could not determine the data-sync source environment for ${EDGE_BUILD_BRANCH}." >&2
-              exit 1
-            fi
-
-            # Read the service declarations deployed to each environment. The
-            # command returns an empty value when an environment has no Solr
-            # service and rejects ambiguous projects with multiple versions.
-            declared_solr_version() {
-              local environment="$1"
-              local service_types
-              local -a versions
-
-              if ! service_types=$(platform services \
-                --project "${PLATFORM_PROJECT}" \
-                --environment "${environment}" \
-                --columns type \
-                --format tsv \
-                --no-header); then
-                echo "ERROR: Could not read services for environment ${environment}." >&2
-                return 1
-              fi
-              mapfile -t versions < <(
-                awk -F '\t' '$1 ~ /^solr:[0-9]+([.][0-9]+)*$/ { sub(/^solr:/, "", $1); print $1 }' \<<< "${service_types}" | sort -u
-              )
-
-              if (( ${#versions[@]} > 1 )); then
-                echo "ERROR: Environment ${environment} declares multiple Solr versions: ${versions[*]}." >&2
-                return 1
-              fi
-              printf '%s\n' "${versions[0]:-}"
-            }
-
-            if ! source_solr_version=$(declared_solr_version "${source_environment}"); then
-              exit 1
-            fi
-            if ! target_solr_version=$(declared_solr_version "${EDGE_BUILD_BRANCH}"); then
-              exit 1
-            fi
-
-            if [[ -z "${target_solr_version}" ]]; then
-              echo "No Solr service is declared for ${EDGE_BUILD_BRANCH}; skipping index rebuild."
-              exit 0
-            fi
-            if [[ "${source_solr_version}" == "${target_solr_version}" ]]; then
-              echo "Source and target both declare Solr ${target_solr_version}; no index rebuild needed."
-              exit 0
-            fi
-
-            echo "Declared Solr version changed: source=${source_solr_version:-none}, target=${target_solr_version}."
-
-            # Fetch the current helper from main only when a rebuild is needed.
-            # This repository intentionally follows the latest HEAD version.
-            script_path="/tmp/reconcile-solr-indexes.sh"
-            script_url="https://raw.githubusercontent.com/dof-dss/webdev-ci/main/scripts/reconcile-solr-indexes.sh?nocache=$(date +%s)"
-            curl --fail --location --silent --show-error "${script_url}" --output "${script_path}"
-            chmod +x "${script_path}"
-
-            platform ssh \
-              --project "${PLATFORM_PROJECT}" \
-              --environment "${EDGE_BUILD_BRANCH}" \
-              -- env RECONCILE_MODE=rebuild SITE_FILTER= INDEX_FILTER= \
-              bash -s < "${script_path}"
-          no_output_timeout: 30m
-
   checkout_code:
     description: "Handle composer access tokens, SSH key fingerprints and code checkout"
     parameters:


### PR DESCRIPTION
Resource contention on solr services and enormous processing time makes this impractical. Retaining the scripts does allow developers to run this process on an ad-hoc basis from their terminal by streaming the script into an upsun ssh session.